### PR TITLE
Golang fixes

### DIFF
--- a/golang/golang_chapter_0040/examples/example_for_playground_007/wrapper_playground
+++ b/golang/golang_chapter_0040/examples/example_for_playground_007/wrapper_playground
@@ -1,0 +1,8 @@
+package main
+
+import "fmt"
+
+func main() {
+    #INJECT-b585472fa
+    fmt.Printf("%v", arr)
+}

--- a/golang/golang_chapter_0040/text.md
+++ b/golang/golang_chapter_0040/text.md
@@ -148,10 +148,23 @@ Oberon
 Pascal
 ```
 
+В случае с range, если вторая переменная не нужна, то ее можно вообще не указывать:
+
+```go {.example_for_playground .example_for_playground_006}
+rooms := [5]string{"Ivan", "Nikolay", "Anna", "Viacheslav", "Petr"}
+
+fmt.Println("Pepople with even room ids:")
+for key := range rooms {
+	if key%2 == 0 {
+		fmt.Println(rooms[key])
+	}
+}
+```
+
 ## Многомерные массивы
 Массивы могут быть многомерными. Вот как можно объявить двумерный массив (матрицу) из чисел типа `int` и задать элементу этой матрицы с индексами `2`, `3` значение `250`:
 
-```go {.example_for_playground .example_for_playground_006}
+```go {.example_for_playground .example_for_playground_007}
 var arr [4][5]int
 
 arr[2][3] = 250

--- a/golang/golang_chapter_0070/text.md
+++ b/golang/golang_chapter_0070/text.md
@@ -112,21 +112,21 @@ fmt.Printf("Hello from %s:%s!", server, port)
 
 Чтобы объявить вариативную функцию, используют многоточие `...`, которое ставят перед типом последнего аргумента.
 
-Функция `addUsers` вариативная:
+Функция `registerUsers` вариативная:
 
 ```go {.example_for_playground .example_for_playground_004}
-var users map[int]string = make(map[int]string)
-var id int
-
-func addUsers(newUsers ...string) {
+func registerUsers(newUsers ...string) map[int]string {
+	var users map[int]string = make(map[int]string)
+	var id int
 	for _, user := range newUsers {
 		users[id] = user
 		id++
 	}
+	return users
 }
 
 func main() {
-	addUsers("ivanov", "petrov", "sidorov")
+	users := registerUsers("ivanov", "petrov", "sidorov")
 	fmt.Println(users)
 }
 ```


### PR DESCRIPTION
1. В 4 главе указал, что при использовании range вторую переменную можно вообще не писать. 
2. Пофиксил глобальные переменные в 7 главе.