### PR TITLE
CPP: Chapter 7: minor fix for task 10

### DIFF
--- a/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_playground
+++ b/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_playground
@@ -85,19 +85,20 @@ struct std::hash<IPv4>
 template <>
 struct std::formatter<IPv4>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4& ip, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4& ip, FormatContext& ctx) const
     {
         return std::format_to(
             ctx.out(), "{}.{}.{}.{}",
             ip.octet<3>(), ip.octet<2>(), ip.octet<1>(), ip.octet<0>());
     }
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // class IPv4Range
@@ -257,12 +258,14 @@ static_assert(std::input_iterator<IPv4Range::const_iterator>);
 template <>
 struct std::formatter<IPv4Range>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4Range& range, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4Range& range, FormatContext& ctx) const
     {
         return std::format_to(ctx.out(), "{}/{}", range.front(), range.mask_bits_count());
     }

--- a/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_run
+++ b/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_run
@@ -85,19 +85,20 @@ struct std::hash<IPv4>
 template <>
 struct std::formatter<IPv4>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4& ip, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4& ip, FormatContext& ctx) const
     {
         return std::format_to(
             ctx.out(), "{}.{}.{}.{}",
             ip.octet<3>(), ip.octet<2>(), ip.octet<1>(), ip.octet<0>());
     }
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // class IPv4Range
@@ -257,12 +258,14 @@ static_assert(std::input_iterator<IPv4Range::const_iterator>);
 template <>
 struct std::formatter<IPv4Range>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4Range& range, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4Range& range, FormatContext& ctx) const
     {
         return std::format_to(ctx.out(), "{}/{}", range.front(), range.mask_bits_count());
     }

--- a/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_test
+++ b/cpp/cpp_chapter_0070/tasks/cpp_chapter_0070_task_0100/wrapper_test
@@ -87,19 +87,20 @@ struct std::hash<IPv4>
 template <>
 struct std::formatter<IPv4>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4& ip, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4& ip, FormatContext& ctx) const
     {
         return std::format_to(
             ctx.out(), "{}.{}.{}.{}",
             ip.octet<3>(), ip.octet<2>(), ip.octet<1>(), ip.octet<0>());
     }
 };
-
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // class IPv4Range
@@ -259,12 +260,14 @@ static_assert(std::input_iterator<IPv4Range::const_iterator>);
 template <>
 struct std::formatter<IPv4Range>
 {
-    constexpr auto parse(std::format_parse_context& ctx)
+    template <class ParseContext>
+    constexpr auto parse(ParseContext& ctx)
     {
         return ctx.begin();
     }
 
-    auto format(const IPv4Range& range, std::format_context& ctx) const
+    template <class FormatContext>
+    auto format(const IPv4Range& range, FormatContext& ctx) const
     {
         return std::format_to(ctx.out(), "{}/{}", range.front(), range.mask_bits_count());
     }


### PR DESCRIPTION
Исправлены трейты форматирования для классов `IPv4` и `IPv4Range`  в задаче 10. Проверить работу форматирования можно так:
```c++
    std::set<IPv4> ip4_set = {{10}, {192, 169}, {224, 80, 9, 1}};
    std::println("ip4_set: {}", ip4_set);

    std::unordered_set<IPv4> ip4_uset = {{10}, {192, 169}, {224, 80, 9, 1}};
    std::println("ip4_uset: {}", ip4_uset);

    std::vector<IPv4> ip4_vec = {{10}, {192, 169}, {224, 80, 9, 1}};
    std::println("ip4_vec: {}", ip4_vec);

    std::list<IPv4> ip4_lst = {{10}, {192, 169}, {224, 80, 9, 1}};
    std::println("ip4_lst: {}", ip4_lst);

    std::map<IPv4, IPv4> ip4_map = {{{10}, {10, 0, 1}}, {{192}, {192, 169}}, {{224}, {224, 80, 9, 1}}};
    std::println("ip4_map: {}", ip4_map);

    std::unordered_map<IPv4, IPv4> ip4_umap = {{{10}, {10, 0, 1}}, {{192}, {192, 169}}, {{224}, {224, 80, 9, 1}}};
    std::println("ip4_umap: {}", ip4_umap);
```